### PR TITLE
Fixed directory separator in imports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Download the package using glide by adding the following into your glide.yaml fi
 
 ```
 import:
-- package: github.com:gophreak/parsetime
+- package: github.com/gophreak/parsetime
   repo: git@github.com:gophreak/parsetime.git
   vcs: git
 ```


### PR DESCRIPTION
It would create folder github.com:gophreak instead of creating folder gophreak under github.com